### PR TITLE
Added .getTime() to insure a millisecond comparison to the heartbeat

### DIFF
--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ Meteor.methods({
 //
 Meteor.setInterval(function() {
     var now = new Date(), overdueTimestamp = new Date(now-inactivityTimeout);
-    Meteor.users.update({heartbeat: {$lt: overdueTimestamp}},
+    Meteor.users.update({heartbeat: {$lt: overdueTimestamp.getTime()}},
                         {$set: {'services.resume.loginTokens': []},
                          $unset: {heartbeat:1}},
                         {multi: true});


### PR DESCRIPTION
My heartbeat, by default, was being stored in milliseconds. The overdueTimestamp seems to be in seconds. Comparison failed every time for me. Adding ".getTime()" insures that the overdueTimeout variable returns a value in milliseconds to the Mongo update routine. This should compare the heartbeat-in-milliseconds to overdueTimeout-in-milliseconds, instead of comparing milliseconds to seconds.
