### PR TITLE
Add support for Meteor 0.7.x.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # meteor-stale-session
 
-Stale session and session timeout handling for [meteorjs](http://www.meteor.com/).
+Stale session and session timeout handling for [meteorjs](http://www.meteor.com/). Supports Meteor 0.7.x.
 
 ## Quick Start
 
@@ -10,7 +10,7 @@ $ mrt add stale-session
 
 ## Key Concepts
 
-When a user logs in to a meteor application, they may gain access to privileged information and functionality.  If they neglect to log off, another user of the same computer can effectively impersonate that user and gains the same rights.  As it currently stands, (meteor 0.6.6.3), login tokens remain valid for eternity so this creates a large window of opportunity for impersonators.
+When a user logs in to a meteor application, they may gain access to privileged information and functionality.  If they neglect to log off, another user of the same computer can effectively impersonate that user and gains the same rights.  As it currently stands, (meteor 0.7.0.1), login tokens remain valid for eternity so this creates a large window of opportunity for impersonators.
 
 This package is designed to detect a user's inactivity and automatically log them off after a configurable amount of time thereby reducing the size of this window to just the inactivity delay.
 
@@ -26,17 +26,33 @@ The plugin uses a heartbeat that is configurable but defaulted to ensure that th
 
 ## Configuration
 
-Configuration is via `Meteor.settings.public`.
+Configuration is via `Meteor.settings.public`, which should be set in `lib/config.js`.
 
 - `staleSessionInactivityTimeout` - the amount of time (in ms) after which, if no activity is noticed, a session will be considered stale - default 30 minutes.
 - `staleSessionPurgeInterval` - interval (in ms) at which stale sessions are purged i.e. found and forcibly logged out - default 1 minute.
 - `staleSessionHeartbeatInterval` - interval (in ms) at which activity heartbeats are sent up to the server - default every 3 minutes.
 - `staleSessionActivityEvents` - the jquery events which are considered indicator of activity e.g. in an on() call - default `mousemove click keydown`
 
+Example `lib/config.js` file:
+
+```js
+if (! Meteor.settings)
+  Meteor.settings = {};
+
+if (! Meteor.settings.public)
+  Meteor.settings.public = {};
+
+Meteor.settings.public.staleSessionInactivityTimeout = 1000 * 60 * 5; // 5 minutes
+Meteor.settings.public.staleSessionHeartbeatInterval = 1000 * 60; // 1 minute
+Meteor.settings.public.staleSessionPurgeInterval = 1000 * 60 * 3; // 3 minutes
+Meteor.settings.public.staleSessionActivityEvents = 'mousemove click keydown';
+```
+
+**Note** that it is important not to wrap the configuration settings in `Meteor.startup`, as then the client may set up the heartbeat intervals before the configuration is set.
 
 ## Background
 
-A meteor project I was working on at [ZUUK](http://www.zuuk.com/), required user sessions to timeout after a period of inactivity.  Meteor itself doesn't currently (0.6.6.3) support this out of the box and, though there were several plugins already available on [Atmosphere](https://atmosphere.meteor.com/), none of them worked reliably for me so I was forced to create my own for the project.  I owe those other packages a great deal of gratitude as this package is effectively just taking ideas from them and making them work in a simpler more reliable fashion for my project.  I'm putting this back into the community in the hope it will help in the same situation.
+A meteor project I was working on at [ZUUK](http://www.zuuk.com/), required user sessions to timeout after a period of inactivity.  Meteor itself doesn't currently (0.7.0.1) support this out of the box and, though there were several plugins already available on [Atmosphere](https://atmosphere.meteor.com/), none of them worked reliably for me so I was forced to create my own for the project.  I owe those other packages a great deal of gratitude as this package is effectively just taking ideas from them and making them work in a simpler more reliable fashion for my project.  I'm putting this back into the community in the hope it will help in the same situation.
 
 ## License
 

--- a/client.js
+++ b/client.js
@@ -2,30 +2,33 @@
 // Client side activity detection for the session timeout
 // - depends on jquery
 //
-// Meteor settings:
-// - staleSessionHeartbeatInterval: interval (in ms) at which activity heartbeats are sent up to the server
-// - staleSessionActivityEvents: the jquery events which are considered indicator of activity e.g. in an on() call.
-//
-var heartbeatInterval = Meteor.settings && Meteor.settings.public && Meteor.settings.public.staleSessionHeartbeatInterval || (3*60*1000); // 3mins
-var activityEvents = Meteor.settings && Meteor.settings.public && Meteor.settings.public.staleSessionActivityEvents || 'mousemove click keydown';
-
-var activityDetected = false;
 
 //
-// periodically send a heartbeat if activity has been detected within the interval
+// Runs in a `Meteor.startup` function so that we don't hook up the heartbeat
+// interval before the server sends `Meteor.settings` to the client.
 //
-Meteor.setInterval(function() {
+Meteor.startup(function(c) {
+  if (! Meteor.settings || ! Meteor.settings.public)
+    return;
+
+  var activityDetected = false;
+  var heartbeatInterval = Meteor.settings.public.staleSessionHeartbeatInterval;
+  var activityEvents = Meteor.settings.public.staleSessionActivityEvents;
+
+  //
+  // periodically send a heartbeat if activity has been detected within the interval
+  //
+  Meteor.setInterval(function() {
     if (Meteor.userId() && activityDetected) {
-        Meteor.call('heartbeat');
-        activityDetected = false;
+      Meteor.call('heartbeat');
+      activityDetected = false;
     }
-}, heartbeatInterval);
+  }, heartbeatInterval);
 
-//
-// detect activity and mark it as detected on any of the following events
-//
-Meteor.startup(function() {
-    $('body').on(activityEvents, function() {
-       activityDetected = true;
-    });
+  //
+  // detect activity and mark it as detected on any of the following events
+  //
+  $('body').on(activityEvents, function() {
+    activityDetected = true;
+  });
 });

--- a/config.js
+++ b/config.js
@@ -1,0 +1,29 @@
+Meteor.startup(function() {
+  if (! Meteor.settings) {
+      Meteor.settings = {};
+  }
+
+  if (! Meteor.settings.public) {
+      Meteor.settings.public = {};
+  }
+
+  // Meteor settings:
+  // - staleSessionHeartbeatInterval: interval (in ms) at which activity heartbeats are sent up to the server
+  // - staleSessionActivityEvents: the jquery events which are considered indicator of activity e.g. in an on() call.
+  // - staleSessionInactivityTimeout: the amount of time (in ms) after which, if no activity is noticed, a session will be considered stale
+  // - staleSessionPurgeInterval: interval (in ms) at which stale sessions are purged i.e. found and forcibly logged out
+  //
+  var defaults = {
+    staleSessionHeartbeatInterval: (3*60*1000), // 3mins
+    staleSessionActivityEvents: 'mousemove click keydown',
+    staleSessionPurgeInterval: (1*60*1000), // 1min
+    staleSessionInactivityTimeout: (30*60*1000) // 30mins
+  };
+
+  for (var key in defaults) {
+    var _default = defaults[key];
+    if (! Meteor.settings.public[key]) {
+      Meteor.settings.public[key] = _default;
+    }
+  }
+});

--- a/package.js
+++ b/package.js
@@ -1,9 +1,11 @@
 Package.describe({
-    'summary': 'Stale session and session timeout handling for meteorjs'
+  'summary': 'Stale session and session timeout handling for meteorjs'
 });
 
 Package.on_use(function(api) {
-    api.use('jquery', 'client');
-    api.add_files('client.js', 'client');
-    api.add_files('server.js', 'server');
+  api.use('deps');
+  api.use('jquery', 'client');
+  api.add_files('config.js', ['client', 'server']);
+  api.add_files('client.js', 'client');
+  api.add_files('server.js', 'server');
 });

--- a/server.js
+++ b/server.js
@@ -1,35 +1,33 @@
-//
-// Server side activity detection for the session timeout
-//
-// Meteor settings:
-// - staleSessionInactivityTimeout: the amount of time (in ms) after which, if no activity is noticed, a session will be considered stale
-// - staleSessionPurgeInterval: interval (in ms) at which stale sessions are purged i.e. found and forcibly logged out
-//
-var staleSessionPurgeInterval = Meteor.settings && Meteor.settings.public && Meteor.settings.public.staleSessionPurgeInterval || (1*60*1000); // 1min
-var inactivityTimeout = Meteor.settings && Meteor.settings.public && Meteor.settings.public.staleSessionInactivityTimeout || (30*60*1000); // 30mins
+Meteor.startup(function() {
+  //
+  // Server side activity detection for the session timeout
+  //
+  var staleSessionPurgeInterval = Meteor.settings.public.staleSessionPurgeInterval;
+  var inactivityTimeout = Meteor.settings.public.staleSessionInactivityTimeout;
 
-//
-// provide a user activity heartbeat method which stamps the user record with a timestamp of the last
-// received activity heartbeat.
-//
-Meteor.methods({
+  //
+  // provide a user activity heartbeat method which stamps the user record with a timestamp of the last
+  // received activity heartbeat.
+  //
+  Meteor.methods({
     heartbeat: function(options) {
-        if (!this.userId) { return; }
-        var user = Meteor.users.findOne(this.userId);
-        if (user) {
-            Meteor.users.update(user._id, {$set: {heartbeat: new Date()}});
-        }
+      if (!this.userId) { return; }
+      var user = Meteor.users.findOne(this.userId);
+      if (user) {
+          Meteor.users.update(user._id, {$set: {heartbeat: new Date()}});
+      }
     }
-});
+  });
 
 
-//
-// periodically purge any stale sessions, removing their login tokens and clearing out the stale heartbeat.
-//
-Meteor.setInterval(function() {
+  //
+  // periodically purge any stale sessions, removing their login tokens and clearing out the stale heartbeat.
+  //
+  Meteor.setInterval(function() {
     var now = new Date(), overdueTimestamp = new Date(now-inactivityTimeout);
     Meteor.users.update({heartbeat: {$lt: overdueTimestamp}},
                         {$set: {'services.resume.loginTokens': []},
                          $unset: {heartbeat:1}},
                         {multi: true});
-}, staleSessionPurgeInterval);
+  }, staleSessionPurgeInterval);
+});


### PR DESCRIPTION
Heya! I wanted to use this in our project, but it took a bit of work to get it working properly with Meteor 0.7.0.1. The biggest problem was that the heartbeat interval would try to hook itself up before the client had received `Meteor.settings`. 

As a bit of a bonus I centralized the config defaults into `config.js`, but that required a bit more refactoring (notably wrapping things in `Meteor.startup` to give the user apps a chance to configure things first).

Criticisms welcome!

Here's the summary:
- Wrap the client interval in a startup function so that the interval
  is set up once `Meteor.settings` reaches the client.
- Centralize defaults in `config.js`
- Wrap server code in `Meteor.startup` so that it runs after user app
  has a chance to configure the settings.
- Add instructions for setting up configuration in `README.md`
