### PR TITLE
Scope event listening to whole document

### DIFF
--- a/client.js
+++ b/client.js
@@ -26,7 +26,7 @@ Meteor.startup(function() {
     //
     // detect activity and mark it as detected on any of the following events
     //
-    $('body').on(activityEvents, function() {
+    $(document).on(activityEvents, function() {
        activityDetected = true;
     });
 });


### PR DESCRIPTION
When we scope it to `body` and the body height is less than the window height, events on the lower parts of the window do not fire activity detection.

When we scope it to document, the whole window is listened for the event.